### PR TITLE
Add dismiss-brand-intro edge function

### DIFF
--- a/supabase/functions/dismiss-brand-intro/index.ts
+++ b/supabase/functions/dismiss-brand-intro/index.ts
@@ -1,0 +1,46 @@
+import { serve } from "https://deno.land/std@0.192.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders, status: 204 });
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") ?? "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+  );
+
+  const authHeader = req.headers.get("authorization") || "";
+  const token = authHeader.replace("Bearer ", "");
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+
+  if (authError || !user) {
+    return new Response(
+      JSON.stringify({ error: "Unauthorized" }),
+      { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+
+  const { error } = await supabase
+    .from("profiles")
+    .update({ has_seen_intro: true })
+    .eq("id", user.id);
+
+  if (error) {
+    return new Response(
+      JSON.stringify({ error: "Failed to update" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+
+  return new Response(
+    JSON.stringify({ success: true }),
+    { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+  );
+});


### PR DESCRIPTION
## Summary
- add `dismiss-brand-intro` edge function
  - authenticates the current user via `auth.getUser`
  - sets `has_seen_intro` in `profiles`

## Testing
- `deno fmt supabase/functions/dismiss-brand-intro/index.ts` *(fails: `deno` not installed)*