### PR TITLE
Add Phyllo connect callback and setup page

### DIFF
--- a/src/components/creator/SocialMediaConnection.tsx
+++ b/src/components/creator/SocialMediaConnection.tsx
@@ -31,10 +31,11 @@ export const SocialMediaConnection = ({ onConnectionSuccess }: SocialMediaConnec
     );
   }
 
+  const handleConnect = (platform: string) => {
+    initializePhylloConnect(platform);
+  };
+
   return (
-    <PhylloConnector 
-      onConnect={initializePhylloConnect}
-      isLoading={isPhylloLoading}
-    />
+    <PhylloConnector onConnect={handleConnect} isLoading={isPhylloLoading} />
   );
 };

--- a/src/components/creator/phyllo/PhylloConnector.tsx
+++ b/src/components/creator/phyllo/PhylloConnector.tsx
@@ -4,11 +4,27 @@ import { Button } from '@/components/ui/button';
 import { LinkIcon } from 'lucide-react';
 
 interface PhylloConnectorProps {
-  onConnect: () => void;
+  onConnect: (platform: string) => void;
   isLoading: boolean;
 }
 
 export const PhylloConnector = ({ onConnect, isLoading }: PhylloConnectorProps) => {
+  const platforms = [
+    'instagram',
+    'tiktok',
+    'youtube',
+    'twitch',
+    'linkedin',
+    'twitter',
+    'reddit',
+    'patreon',
+    'spotify',
+    'facebook',
+    'discord',
+    'pinterest',
+    'shopify'
+  ];
+
   return (
     <div className="border-t pt-6">
       <div className="space-y-4">
@@ -16,18 +32,22 @@ export const PhylloConnector = ({ onConnect, isLoading }: PhylloConnectorProps) 
           <h3 className="text-lg font-semibold mb-2">Connect Your Social Media</h3>
           <p className="text-sm text-muted-foreground mb-4">
             Connect your social media accounts to showcase your reach and get ready for brand collaborations.
-            {isLoading && " You'll be redirected to connect your accounts securely."}
           </p>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={onConnect}
-            disabled={isLoading}
-            className="flex items-center gap-2"
-          >
-            <LinkIcon className="h-4 w-4" />
-            {isLoading ? 'Redirecting...' : 'Connect Your Social Platforms'}
-          </Button>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+            {platforms.map((p) => (
+              <Button
+                key={p}
+                type="button"
+                variant="outline"
+                onClick={() => onConnect(p)}
+                disabled={isLoading}
+                className="flex items-center gap-2"
+              >
+                <LinkIcon className="h-4 w-4" />
+                {p}
+              </Button>
+            ))}
+          </div>
           {isLoading && (
             <p className="text-xs text-muted-foreground mt-2">
               Please wait while we prepare your secure connection...

--- a/src/hooks/usePhylloConnect.ts
+++ b/src/hooks/usePhylloConnect.ts
@@ -79,7 +79,7 @@ export const usePhylloConnect = (
     }
   };
 
-  const initializePhylloConnect = async () => {
+  const initializePhylloConnect = async (platform: string) => {
     if (!userId) {
       toast.error('Please log in to connect your social accounts');
       return;
@@ -88,7 +88,7 @@ export const usePhylloConnect = (
     setIsPhylloLoading(true);
     
     try {
-      await initializePhylloRedirect(userId, userEmail);
+      await initializePhylloRedirect(userId, userEmail, platform);
     } catch (error) {
       console.error('💥 Error initializing Phyllo Connect:', error);
       toast.error(`Failed to load social account connection: ${error.message}`);

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -214,30 +214,44 @@ export type Database = {
       }
       connected_accounts: {
         Row: {
-          account_id: string
-          connected_at: string | null
           id: string
+          creator_id: string | null
           platform: string
-          user_id: string | null
-          workplatform_id: string
+          external_user_id: string | null
+          access_token: string | null
+          refresh_token: string | null
+          expires_at: string | null
+          connected_at: string | null
         }
         Insert: {
-          account_id: string
-          connected_at?: string | null
           id?: string
+          creator_id?: string | null
           platform: string
-          user_id?: string | null
-          workplatform_id: string
+          external_user_id?: string | null
+          access_token?: string | null
+          refresh_token?: string | null
+          expires_at?: string | null
+          connected_at?: string | null
         }
         Update: {
-          account_id?: string
-          connected_at?: string | null
           id?: string
+          creator_id?: string | null
           platform?: string
-          user_id?: string | null
-          workplatform_id?: string
+          external_user_id?: string | null
+          access_token?: string | null
+          refresh_token?: string | null
+          expires_at?: string | null
+          connected_at?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "connected_accounts_creator_id_fkey",
+            columns: ["creator_id"],
+            isOneToOne: false,
+            referencedRelation: "profiles",
+            referencedColumns: ["id"]
+          },
+        ]
       }
       creator_industries: {
         Row: {

--- a/src/pages/creator/phyllo/Callback.tsx
+++ b/src/pages/creator/phyllo/Callback.tsx
@@ -1,0 +1,70 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from '@/components/ui/sonner';
+import { supabase } from '@/integrations/supabase/client';
+import { getRedirectData, clearRedirectData } from '@/utils/phylloRedirectData';
+
+const PhylloCallback = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const finalizeConnection = async () => {
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get('code');
+      const state = params.get('state');
+      const err = params.get('error');
+
+      if (err) {
+        toast.error('Failed to connect social account.');
+        clearRedirectData();
+        navigate('/creator/profile/setup', { replace: true });
+        return;
+      }
+
+      if (!code || !state) {
+        toast.error('Invalid callback parameters.');
+        clearRedirectData();
+        navigate('/creator/profile/setup', { replace: true });
+        return;
+      }
+
+      const redirectData = getRedirectData();
+      if (!redirectData) {
+        toast.error('Session expired. Please try again.');
+        navigate('/creator/profile/setup', { replace: true });
+        return;
+      }
+
+      const { error: fnError } = await supabase.functions.invoke('phyllo-callback', {
+        body: { code, state, platform: redirectData.platform }
+      });
+
+      clearRedirectData();
+
+      if (fnError) {
+        toast.error('Failed to connect account.');
+        navigate('/creator/profile/setup', { replace: true });
+        return;
+      }
+
+      toast.success('Account connected successfully!');
+      navigate('/creator/dashboard', { replace: true });
+    };
+
+    finalizeConnection();
+  }, [navigate]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="text-center space-y-4">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto" />
+        <div className="space-y-2">
+          <p className="text-lg font-medium">Processing Connection</p>
+          <p className="text-muted-foreground">Please wait while we connect your account...</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PhylloCallback;

--- a/src/pages/creator/profile/Setup.tsx
+++ b/src/pages/creator/profile/Setup.tsx
@@ -1,0 +1,18 @@
+import CreatorLayout from '@/components/layouts/CreatorLayout';
+import { SocialMediaConnection } from '@/components/creator/SocialMediaConnection';
+
+const ProfileSetup = () => {
+  return (
+    <CreatorLayout>
+      <div className="container mx-auto p-6 space-y-6">
+        <h1 className="text-2xl font-bold">Connect Your Social Accounts</h1>
+        <p className="text-muted-foreground">
+          Link your social media profiles to start sharing analytics with brands.
+        </p>
+        <SocialMediaConnection />
+      </div>
+    </CreatorLayout>
+  );
+};
+
+export default ProfileSetup;

--- a/src/routes/CreatorRoutes.tsx
+++ b/src/routes/CreatorRoutes.tsx
@@ -7,19 +7,28 @@ import CreatorDeals from "@/pages/creator/Deals";
 import CreatorCampaigns from "@/pages/creator/Campaigns";
 import CampaignDetail from "@/pages/creator/CampaignDetail";
 import ContentUpload from "@/pages/creator/ContentUpload";
-import ConnectCallback from "@/pages/connect/Callback";
+import PhylloCallback from "@/pages/creator/phyllo/Callback";
+import ProfileSetup from "@/pages/creator/profile/Setup";
 
 export const CreatorRoutes = () => {
   return (
     <Routes>
       {/* Creator Dashboard Routes */}
-      <Route 
-        path="" 
+      <Route
+        path=""
         element={
           <ProtectedRoute requiredRole="creator">
             <CreatorDashboard />
           </ProtectedRoute>
-        } 
+        }
+      />
+      <Route
+        path="profile/setup"
+        element={
+          <ProtectedRoute requiredRole="creator">
+            <ProfileSetup />
+          </ProtectedRoute>
+        }
       />
       <Route 
         path="analytics" 
@@ -65,13 +74,13 @@ export const CreatorRoutes = () => {
       />
       
       {/* Social Media Connection Callback */}
-      <Route 
-        path="connect/callback" 
+      <Route
+        path="phyllo/callback"
         element={
           <ProtectedRoute requiredRole="creator">
-            <ConnectCallback />
+            <PhylloCallback />
           </ProtectedRoute>
-        } 
+        }
       />
     </Routes>
   );

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,7 +8,7 @@ import DataDeletion from "@/pages/DataDeletion";
 import PrivacyPolicy from "@/pages/PrivacyPolicy";
 import TermsOfService from "@/pages/TermsOfService";
 import NotFound from "@/pages/NotFound";
-import ConnectCallback from "@/pages/connect/Callback";
+import PhylloCallback from "@/pages/creator/phyllo/Callback";
 import AdminRoutes from "./AdminRoutes";
 import { BrandRoutes } from "./BrandRoutes";
 import { CreatorRoutes } from "./CreatorRoutes";
@@ -51,13 +51,13 @@ export const AppRoutes = () => {
       <Route path="/tos" element={<TermsOfService />} />
       
       {/* Social Media Connection Callback - accessible to all authenticated users */}
-      <Route 
-        path="/connect/callback" 
+      <Route
+        path="/creator/phyllo/callback"
         element={
           <ProtectedRoute>
-            <ConnectCallback />
+            <PhylloCallback />
           </ProtectedRoute>
-        } 
+        }
       />
       
       {/* Role-based routes */}

--- a/src/utils/phylloInitialization.ts
+++ b/src/utils/phylloInitialization.ts
@@ -2,8 +2,12 @@
 import { generatePhylloToken } from './phylloToken';
 import { storeRedirectData } from './phylloRedirectData';
 
-export const createPhylloRedirectUrl = (token: string, userId: string): string => {
-  const returnUrl = `${window.location.origin}/creator/connect/callback`;
+export const createPhylloRedirectUrl = (
+  token: string,
+  userId: string,
+  platform: string
+): string => {
+  const returnUrl = `${window.location.origin}/creator/phyllo/callback`;
   
   const phylloParams = new URLSearchParams({
     clientDisplayName: 'OpenSocials',
@@ -25,7 +29,8 @@ export const createPhylloRedirectUrl = (token: string, userId: string): string =
 
 export const initializePhylloRedirect = async (
   userId: string,
-  userEmail: string | undefined
+  userEmail: string | undefined,
+  platform: string
 ): Promise<void> => {
   console.log('🚀 Starting Phyllo Connect initialization...');
   console.log('🔑 Generating fresh Phyllo token...');
@@ -37,11 +42,11 @@ export const initializePhylloRedirect = async (
   }
 
   // Store data for redirect return
-  storeRedirectData(userId, userEmail, freshToken);
+  storeRedirectData(userId, userEmail, freshToken, platform);
   
   console.log('🔄 Redirecting to Phyllo Connect URL...');
   
-  const phylloUrl = createPhylloRedirectUrl(freshToken, userId);
+  const phylloUrl = createPhylloRedirectUrl(freshToken, userId, platform);
   
   // Add a small delay to ensure localStorage is saved
   await new Promise(resolve => setTimeout(resolve, 100));

--- a/src/utils/phylloRedirectData.ts
+++ b/src/utils/phylloRedirectData.ts
@@ -3,14 +3,21 @@ interface PhylloRedirectData {
   userId: string;
   userEmail?: string;
   token: string;
+  platform: string;
   timestamp: number;
 }
 
-export const storeRedirectData = (userId: string, userEmail: string | undefined, token: string): void => {
+export const storeRedirectData = (
+  userId: string,
+  userEmail: string | undefined,
+  token: string,
+  platform: string
+): void => {
   const redirectData: PhylloRedirectData = {
     userId,
     userEmail,
     token,
+    platform,
     timestamp: Date.now()
   };
   

--- a/supabase/functions/phyllo-callback/index.ts
+++ b/supabase/functions/phyllo-callback/index.ts
@@ -1,0 +1,97 @@
+import { serve } from "https://deno.land/std@0.192.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+  );
+
+  try {
+    const { code, state, platform } = await req.json();
+
+    if (!code || !state || !platform) {
+      return new Response(
+        JSON.stringify({ error: "Missing code, state or platform" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const authHeader = req.headers.get("Authorization") || "";
+    const token = authHeader.replace("Bearer ", "");
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !user) {
+      return new Response(
+        JSON.stringify({ error: "Invalid auth token" }),
+        { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const basicAuth = Deno.env.get("PHYLLO_BASIC_TOKEN")!;
+
+    const exchangeRes = await fetch("https://api.staging.getphyllo.com/v1/oauth/token", {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${basicAuth}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ code, state }),
+    });
+
+    if (!exchangeRes.ok) {
+      const text = await exchangeRes.text();
+      console.error("Phyllo token exchange failed", text);
+      return new Response(
+        JSON.stringify({ error: "Token exchange failed" }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const tokenData = await exchangeRes.json();
+
+    const expires_at = tokenData.expires_in
+      ? new Date(Date.now() + tokenData.expires_in * 1000).toISOString()
+      : null;
+
+    const { error } = await supabase
+      .from("connected_accounts")
+      .upsert({
+        creator_id: user.id,
+        platform,
+        external_user_id: tokenData.external_id ?? null,
+        access_token: tokenData.access_token ?? null,
+        refresh_token: tokenData.refresh_token ?? null,
+        expires_at,
+        connected_at: new Date().toISOString(),
+      }, { onConflict: "creator_id,platform" });
+
+    if (error) {
+      console.error("Database insert failed", error);
+      return new Response(
+        JSON.stringify({ error: "Failed to store connection" }),
+        { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({ success: true }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  } catch (err) {
+    console.error("Unexpected error", err);
+    return new Response(
+      JSON.stringify({ error: "Server error" }),
+      { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+    );
+  }
+});

--- a/supabase/migrations/20250601_add_connected_accounts_table.sql
+++ b/supabase/migrations/20250601_add_connected_accounts_table.sql
@@ -1,0 +1,14 @@
+-- Create connected_accounts table
+create table if not exists public.connected_accounts (
+  id uuid primary key default uuid_generate_v4(),
+  creator_id uuid references public.profiles(id) on delete cascade,
+  platform text not null,
+  external_user_id text,
+  access_token text,
+  refresh_token text,
+  expires_at timestamptz,
+  connected_at timestamptz default now()
+);
+
+create index if not exists connected_accounts_platform_idx on public.connected_accounts(platform);
+create index if not exists connected_accounts_creator_platform_idx on public.connected_accounts(creator_id, platform);


### PR DESCRIPTION
## Summary
- add `connected_accounts` table migration
- implement `phyllo-callback` edge function
- store selected platform for Phyllo redirects
- create Phyllo callback page and profile setup page
- list platforms in connector component
- route callback and setup pages in creator router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*