### PR TITLE
Refactor supabase deletion logic

### DIFF
--- a/supabase/functions/meta-delete/index.ts
+++ b/supabase/functions/meta-delete/index.ts
@@ -1,9 +1,7 @@
 
 // @ts-ignore
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
-
-const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-const SUPABASE_URL = "https://pcnrnciwgdrukzciwexi.supabase.co";
+import { deleteSocialAccount } from "../shared/meta-delete-helper.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -30,32 +28,23 @@ serve(async (req) => {
       );
     }
 
-    const res = await fetch(`${SUPABASE_URL}/rest/v1/social_accounts?profile_id=eq.${user_id}`, {
-      method: "DELETE",
-      headers: {
-        "apikey": SUPABASE_SERVICE_ROLE_KEY,
-        "Authorization": `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
-        "Content-Type": "application/json",
-        "Prefer": "return=representation"
-      }
-    });
+    const { success, error } = await deleteSocialAccount(user_id, "profile_id");
 
-    if (!res.ok) {
-      const error = await res.text();
+    if (!success) {
       return new Response(
         JSON.stringify({ error: `Deletion failed: ${error}` }),
-        { 
+        {
           status: 500,
-          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' }
         }
       );
     }
 
     return new Response(
       JSON.stringify({ success: true, user_id }),
-      { 
+      {
         status: 200,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
       }
     );
   } catch (err) {

--- a/supabase/functions/shared/meta-delete-helper.ts
+++ b/supabase/functions/shared/meta-delete-helper.ts
@@ -1,0 +1,53 @@
+// Shared helper to delete a social account and log the result to Supabase
+
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const SUPABASE_URL = "https://pcnrnciwgdrukzciwexi.supabase.co";
+
+interface DeleteResult {
+  success: boolean;
+  error?: string;
+}
+
+async function logDeauth(accountId: string, status: string, error?: string) {
+  await fetch(`${SUPABASE_URL}/rest/v1/deauth_logs`, {
+    method: "POST",
+    headers: {
+      apikey: SUPABASE_SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      platform: "meta",
+      account_id: accountId,
+      status,
+      error_message: error ?? null,
+    }),
+  });
+}
+
+export async function deleteSocialAccount(
+  id: string,
+  field: "account_id" | "profile_id" = "account_id",
+): Promise<DeleteResult> {
+  const res = await fetch(
+    `${SUPABASE_URL}/rest/v1/social_accounts?${field}=eq.${id}`,
+    {
+      method: "DELETE",
+      headers: {
+        apikey: SUPABASE_SERVICE_ROLE_KEY,
+        Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+        "Content-Type": "application/json",
+        Prefer: "return=representation",
+      },
+    },
+  );
+
+  if (!res.ok) {
+    const error = await res.text();
+    await logDeauth(id, "failed", error);
+    return { success: false, error };
+  }
+
+  await logDeauth(id, "success");
+  return { success: true };
+}


### PR DESCRIPTION
## Summary
- add a shared helper to delete Meta social accounts and log results
- update meta-deauth and meta-delete functions to use the new helper

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*