### PR TITLE
Handle brief file uploads in parallel

### DIFF
--- a/src/components/brand/project/BriefUploader.tsx
+++ b/src/components/brand/project/BriefUploader.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
 import { Upload, FilePlus, FileCheck } from 'lucide-react';
 
 interface BriefUploaderProps {
@@ -8,6 +9,7 @@ interface BriefUploaderProps {
   handleFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   briefFiles: File[];
   isUploading: boolean;
+  uploadProgress: number;
   handleProgressCampaign: () => void;
 }
 
@@ -16,6 +18,7 @@ export const BriefUploader: React.FC<BriefUploaderProps> = ({
   handleFileChange,
   briefFiles,
   isUploading,
+  uploadProgress,
   handleProgressCampaign,
 }) => {
   return (
@@ -50,23 +53,32 @@ export const BriefUploader: React.FC<BriefUploaderProps> = ({
         {briefFiles.length > 0 && (
           <div className="mt-4 w-full">
             <p className="text-sm font-medium text-gray-700 mb-2">Selected Files:</p>
-            <div className="space-y-2">
-              {briefFiles.map((file, index) => (
-                <div key={index} className="flex items-center bg-white p-2 rounded border shadow-sm">
-                  <FileCheck className="h-4 w-4 text-green-500 mr-2" />
-                  <span className="text-sm truncate">{file.name}</span>
-                  <span className="text-xs text-gray-500 ml-2">
-                    ({Math.round(file.size / 1024)} KB)
-                  </span>
-                </div>
-              ))}
+          <div className="space-y-2">
+            {briefFiles.map((file, index) => (
+              <div key={index} className="flex items-center bg-white p-2 rounded border shadow-sm">
+                <FileCheck className="h-4 w-4 text-green-500 mr-2" />
+                <span className="text-sm truncate">{file.name}</span>
+                <span className="text-xs text-gray-500 ml-2">
+                  ({Math.round(file.size / 1024)} KB)
+                </span>
+              </div>
+            ))}
+          </div>
+
+          {isUploading && (
+            <div className="mt-3">
+              <Progress value={uploadProgress} className="h-2.5 bg-gray-100" />
+              <p className="text-xs text-gray-600 text-center mt-1">
+                {Math.round(uploadProgress)}%
+              </p>
             </div>
-            
-            <Button 
-              onClick={handleProgressCampaign} 
-              className="mt-4 w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700"
-              disabled={isUploading}
-            >
+          )}
+
+          <Button
+            onClick={handleProgressCampaign}
+            className="mt-4 w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700"
+            disabled={isUploading}
+          >
               {isUploading ? 'Uploading...' : 'Upload Files & Continue'}
             </Button>
           </div>

--- a/src/hooks/useBriefFiles.ts
+++ b/src/hooks/useBriefFiles.ts
@@ -7,11 +7,13 @@ import { ContentRequirements } from '@/types/project';
 export function useBriefFiles(projectId: string | undefined) {
   const [briefFiles, setBriefFiles] = useState<File[]>([]);
   const [isUploading, setIsUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
   const { toast } = useToast();
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files.length > 0) {
       setBriefFiles(Array.from(e.target.files));
+      setUploadProgress(0);
     }
   };
 
@@ -19,31 +21,56 @@ export function useBriefFiles(projectId: string | undefined) {
     if (!projectId || briefFiles.length === 0) return contentRequirements;
 
     setIsUploading(true);
+    setUploadProgress(0);
     try {
-      // This would be an actual file upload to Supabase storage
-      // For now we'll just simulate it with a delay
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      // Prepare updated content requirements with brief info
+      // Ensure the storage bucket exists
+      const { data: buckets } = await supabase.storage.listBuckets();
+      const bucketExists = buckets?.some(b => b.name === 'campaign-briefs');
+      if (!bucketExists) {
+        const { error: bucketError } = await supabase.storage.createBucket('campaign-briefs', {
+          public: true
+        });
+        if (bucketError) throw bucketError;
+      }
+
+      // Map each selected file to an upload promise
+      const uploads = briefFiles.map(async (file, index) => {
+        const ext = file.name.split('.').pop();
+        const filePath = `${projectId}/${Date.now()}-${index}.${ext}`;
+        const { data, error } = await supabase.storage
+          .from('campaign-briefs')
+          .upload(filePath, file);
+        if (error) throw error;
+
+        // update aggregated progress
+        setUploadProgress(prev => prev + (100 / briefFiles.length));
+
+        const { data: urlData } = supabase.storage
+          .from('campaign-briefs')
+          .getPublicUrl(data.path);
+        return urlData.publicUrl;
+      });
+
+      const uploadedUrls = await Promise.all(uploads);
+
       const updatedContentRequirements: ContentRequirements = {
         ...(contentRequirements || {}),
         brief_uploaded: true,
-        brief_files: briefFiles.map(file => file.name)
+        brief_files: uploadedUrls
       };
-      
-      // Update project record with brief_uploaded flag
+
       const { error: updateError } = await supabase
         .from('projects')
         .update({ content_requirements: updatedContentRequirements })
         .eq('id', projectId);
-        
+
       if (updateError) throw updateError;
-      
+
       toast({
         title: 'Brief Uploaded',
         description: 'Campaign brief and materials have been uploaded successfully',
       });
-      
+
       return updatedContentRequirements;
     } catch (error) {
       console.error('Error uploading files:', error);
@@ -55,12 +82,14 @@ export function useBriefFiles(projectId: string | undefined) {
       return contentRequirements;
     } finally {
       setIsUploading(false);
+      setUploadProgress(100);
     }
   };
 
   return {
     briefFiles,
     isUploading,
+    uploadProgress,
     handleFileChange,
     uploadBriefFiles
   };

--- a/src/hooks/useProjectDetails.ts
+++ b/src/hooks/useProjectDetails.ts
@@ -18,11 +18,12 @@ export function useProjectDetails() {
   const navigate = useNavigate();
 
   // Import functionality from smaller hooks
-  const { 
-    briefFiles, 
-    isUploading, 
+  const {
+    briefFiles,
+    isUploading,
+    uploadProgress,
     handleFileChange,
-    uploadBriefFiles 
+    uploadBriefFiles
   } = useBriefFiles(id);
   
   const { 
@@ -129,6 +130,7 @@ export function useProjectDetails() {
     currentStep,
     briefFiles,
     isUploading,
+    uploadProgress,
     briefUploaded,
     nextStepBlocked,
     showBlockedAlert,


### PR DESCRIPTION
## Summary
- upload campaign brief files concurrently
- track aggregate upload progress
- surface progress in the BriefUploader UI
- return progress from `useBriefFiles` and `useProjectDetails`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*